### PR TITLE
Removed seed value so trucks will be fully randomized

### DIFF
--- a/src/main/java/unl/cse/trucks/Truck.java
+++ b/src/main/java/unl/cse/trucks/Truck.java
@@ -103,7 +103,7 @@ public class Truck {
 
         String licensePlate = RandomStringUtils.randomAlphabetic(3) + " "
                 + RandomStringUtils.randomNumeric(3);
-        java.util.Random randomNumberGenerator = new java.util.Random(System.currentTimeMillis());
+        java.util.Random randomNumberGenerator = new java.util.Random();
 
         int carryingCapacity = Truck.CARRYINGCAPACITY_MIN+randomNumberGenerator.nextInt(Truck.CARRYINGCAPACITY_MAX-Truck.CARRYINGCAPACITY_MIN);
         


### PR DESCRIPTION
## Why is this PR necessary?
Every time I've done this lab, students have been confused as to why the license plates are randomized but nothing else is, thinking that they did something wrong. While not changing anything critical, this PR should remove that level of confusion.

## What was changed?
Previously, using System.currentTimeMilis() would produce output like this, where many trucks in a row would get the same randomized values for everything but the license plate
![before](https://user-images.githubusercontent.com/44409145/77857748-156a3780-71c5-11ea-9235-310609337612.PNG)

After removing the seed value, output looks like this:
![after](https://user-images.githubusercontent.com/44409145/77857758-20bd6300-71c5-11ea-96f8-7a60856f85d3.PNG)

